### PR TITLE
Add mobile emulation support with device toolbar and controls

### DIFF
--- a/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
@@ -50,7 +50,7 @@ object DeviceEmulationConstants {
   const val USER_AGENT_NEST_HUB = "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
   const val USER_AGENT_NEST_HUB_MAX = "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
 
-  // Default Browser User Agent
+  // Default User Agent
   const val USER_AGENT_DEFAULT_BROWSER =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 /CefSharp Browser 90.0"
 

--- a/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
@@ -10,8 +10,8 @@ object DeviceEmulationConstants {
   const val DEVICE_FRAME_PADDING_HALF = 20 // Padding on one side
   const val SCALE_PADDING_FACTOR = 0.9 // 90% scale to ensure padding
   const val DEVICE_FRAME_INNER_PADDING = 2 // Inner padding for device frame border
-  const val RESPONSIVE_MODE_WIDTH = 400
-  const val RESPONSIVE_MODE_HEIGHT = 626
+  const val DEFAULT_RESPONSIVE_WIDTH = 400
+  const val DEFAULT_RESPONSIVE_HEIGHT = 626
   // Spinner Constraints
   const val MIN_DEVICE_DIMENSION = 50
   const val MAX_DEVICE_DIMENSION = 9999

--- a/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
@@ -1,0 +1,75 @@
+package com.github.gbrowser.actions
+
+/**
+ * Constants used for device emulation functionality.
+ * Centralizes magic numbers and strings for better maintainability.
+ */
+object DeviceEmulationConstants {
+  // UI Layout Constants
+  const val DEVICE_FRAME_PADDING = 40 // Total padding (20px on each side)
+  const val DEVICE_FRAME_PADDING_HALF = 20 // Padding on one side
+  const val SCALE_PADDING_FACTOR = 0.9 // 90% scale to ensure padding
+  const val DEVICE_FRAME_INNER_PADDING = 2 // Inner padding for device frame border
+
+  // Spinner Constraints
+  const val MIN_DEVICE_DIMENSION = 50
+  const val MAX_DEVICE_DIMENSION = 9999
+  const val DIMENSION_STEP = 1
+
+  // Zoom Constants
+  const val ZOOM_FACTOR = 1.2
+  const val DEFAULT_ZOOM_PERCENTAGE = "100%"
+
+  // Component Dimensions
+  const val SPINNER_WIDTH = 80
+  const val ROTATE_BUTTON_WIDTH = 30
+  const val ROTATE_BUTTON_HEIGHT = 26
+  const val TOOLBAR_HORIZONTAL_GAP = 5
+  const val TOOLBAR_VERTICAL_GAP = 2
+  const val TOOLBAR_PADDING = 5
+  const val TOOLBAR_HORIZONTAL_PADDING = 10
+  const val LABEL_HORIZONTAL_PADDING = 3
+  const val HORIZONTAL_STRUT_SIZE = 10
+
+  // User Agent Strings (Updated to latest versions)
+  const val MOBILE_USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+
+  // Device-specific User Agents
+  const val USER_AGENT_IPHONE_SE = "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+  const val USER_AGENT_IPHONE_XR = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
+  const val USER_AGENT_IPHONE_12_PRO = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+  const val USER_AGENT_PIXEL_7 = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_SAMSUNG_S8_PLUS = "Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_SAMSUNG_S20_ULTRA = "Mozilla/5.0 (Linux; Android 10; SM-G988B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_SAMSUNG_A51_71 = "Mozilla/5.0 (Linux; Android 11; SM-A515F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_GALAXY_Z_FOLD_5 = "Mozilla/5.0 (Linux; Android 13; SM-F946B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_IPAD_MINI = "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+  const val USER_AGENT_SURFACE_PRO_7 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.0.0"
+  const val USER_AGENT_SURFACE_DUO = "Mozilla/5.0 (Linux; Android 11; Surface Duo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+  const val USER_AGENT_ASUS_ZENBOOK_FOLD = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+  const val USER_AGENT_NEST_HUB = "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
+  const val USER_AGENT_NEST_HUB_MAX = "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
+
+  // Default Browser User Agent
+  const val USER_AGENT_DEFAULT_BROWSER =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 /CefSharp Browser 90.0"
+
+  // Component Names for Testing
+  const val DEVICE_WIDTH_SPINNER_NAME = "device-width-spinner"
+  const val DEVICE_HEIGHT_SPINNER_NAME = "device-height-spinner"
+
+  // Chrome DevTools Colors
+  const val CHROME_DEVTOOLS_DARK_BG = 0x202124
+  const val CHROME_DEVTOOLS_LIGHT_BG = 0xF3F3F3
+  const val CHROME_DEVTOOLS_TOOLBAR_DARK_BG = 0x2B2D30
+  const val CHROME_DEVTOOLS_TOOLBAR_LIGHT_BG = 0xF3F3F3
+  const val CHROME_DEVTOOLS_DARK_BORDER = 0x393B3F
+  const val CHROME_DEVTOOLS_LIGHT_BORDER = 0xD0D0D0
+  const val CHROME_DEVICE_FRAME_DARK_BG = 0x292A2D
+  const val CHROME_DEVICE_FRAME_LIGHT_BG = 0xFFFFFF
+  const val CHROME_DEVICE_FRAME_DARK_BORDER = 0x3C3F41
+  const val CHROME_DEVICE_FRAME_LIGHT_BORDER = 0xD0D0D0
+
+  // Timing Constants
+  const val THEME_UPDATE_DELAY_MS = 100
+}

--- a/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/DeviceEmulationConstants.kt
@@ -10,7 +10,8 @@ object DeviceEmulationConstants {
   const val DEVICE_FRAME_PADDING_HALF = 20 // Padding on one side
   const val SCALE_PADDING_FACTOR = 0.9 // 90% scale to ensure padding
   const val DEVICE_FRAME_INNER_PADDING = 2 // Inner padding for device frame border
-
+  const val RESPONSIVE_MODE_WIDTH = 400
+  const val RESPONSIVE_MODE_HEIGHT = 626
   // Spinner Constraints
   const val MIN_DEVICE_DIMENSION = 50
   const val MAX_DEVICE_DIMENSION = 9999

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleAction.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleAction.kt
@@ -1,26 +1,13 @@
 package com.github.gbrowser.actions
 
 import com.github.gbrowser.i18n.GBrowserBundle
-import com.github.gbrowser.ui.gcef.GCefBrowser
-import com.github.gbrowser.util.*
-import com.intellij.icons.AllIcons
+import com.github.gbrowser.util.GBrowserUtil
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.DumbAware
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.ComboBox
-import com.intellij.openapi.ui.SimpleToolWindowPanel
-import com.intellij.ui.JBColor
-import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBPanel
-import com.intellij.util.ui.JBUI
-import java.awt.*
-import javax.swing.*
-import kotlin.math.ln
 
-@Suppress("DuplicatedCode")
 class GBrowserMobileToggleAction : ToggleAction(
   GBrowserBundle.message("action.GBrowserMobileToggleAction.text"),
   GBrowserBundle.message("action.GBrowserMobileToggleAction.description"),
@@ -32,17 +19,7 @@ class GBrowserMobileToggleAction : ToggleAction(
     private val LOG = thisLogger()
     private val deviceEmulationState = mutableMapOf<String, DeviceEmulationState>()
     private val stateLock = Any() // Lock for synchronizing state access
-
-    // Chrome DevTools colors - matching the actual Chrome DevTools colors
-    private val CHROME_DEVTOOLS_DARK_BG = JBColor(Color(0x202124), Color(0x202124)) // Chrome's actual dark background (lighter gray)
-    private val CHROME_DEVTOOLS_LIGHT_BG = JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome's actual light background
-
-    // Default responsive mode dimensions
-    private const val DEFAULT_RESPONSIVE_WIDTH = 400
-    private const val DEFAULT_RESPONSIVE_HEIGHT = 626
-
-    // Zoom calculation constant
-    private const val ZOOM_FACTOR = 1.2
+    
 
     /**
      * Cleans up device emulation state for a disposed browser.
@@ -50,7 +27,7 @@ class GBrowserMobileToggleAction : ToggleAction(
      */
     fun cleanupBrowserState(browserId: String) {
       synchronized(stateLock) {
-        deviceEmulationState.remove(browserId)?.let { state ->
+        deviceEmulationState.remove(browserId)?.also { state ->
           LOG.debug("GBrowserMobileToggleAction: Cleaned up device emulation state for browser $browserId")
           // Clean up any UI components
           state.browserWrapper?.removeAll()
@@ -62,16 +39,6 @@ class GBrowserMobileToggleAction : ToggleAction(
     }
   }
 
-  private data class DeviceEmulationState(
-    var isActive: Boolean = false,
-    var currentDevice: String? = null,
-    var deviceToolbar: JPanel? = null,
-    var browserWrapper: JPanel? = null,
-    var isRotated: Boolean = false,
-    var currentWidth: Int = DEFAULT_RESPONSIVE_WIDTH,
-    var currentHeight: Int = DEFAULT_RESPONSIVE_HEIGHT
-  )
-
   override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
   override fun isSelected(e: AnActionEvent): Boolean {
@@ -81,7 +48,7 @@ class GBrowserMobileToggleAction : ToggleAction(
       return false
     }
 
-    val browser = getCurrentBrowser(project)
+    val browser = GBrowserMobileToggleActionUtils.getCurrentBrowser(project)
     if (browser == null) {
       LOG.debug("GBrowserMobileToggleAction: isSelected - no browser found")
       return false
@@ -96,12 +63,12 @@ class GBrowserMobileToggleAction : ToggleAction(
 
   override fun setSelected(e: AnActionEvent, state: Boolean) {
     val project = e.project ?: return
-    val browser = getCurrentBrowser(project) ?: return
+    val browser = GBrowserMobileToggleActionUtils.getCurrentBrowser(project) ?: return
 
     LOG.info("GBrowserMobileToggleAction: setSelected called with state=$state")
 
     // Try to get the browser panel - handle both regular browser and DevTools
-    val browserPanel = getBrowserPanel(project)
+    val browserPanel = GBrowserMobileToggleActionUtils.getBrowserPanel(project)
 
     // If we couldn't find the browser panel directly, it might be in DevTools
     if (browserPanel == null) {
@@ -139,16 +106,32 @@ class GBrowserMobileToggleAction : ToggleAction(
     }
 
     if (state) {
-      enableDeviceEmulation(browserPanel, browser)
+      val emulationState = synchronized(stateLock) {
+        val s = deviceEmulationState.getOrPut(browser.id) { DeviceEmulationState() }
+        if (s.isActive) return
+        s.isActive = true
+        s
+      }
+      GBrowserMobileToggleActionHelper.enableDeviceEmulation(browserPanel, browser, emulationState)
     } else {
-      disableDeviceEmulation(browserPanel, browser)
+      val emulationState = synchronized(stateLock) {
+        val s = deviceEmulationState[browser.id] ?: return
+        if (!s.isActive) return
+        s.isActive = false
+        s
+      }
+      GBrowserMobileToggleActionHelper.disableDeviceEmulation(browserPanel, browser, emulationState) {
+        synchronized(stateLock) {
+          deviceEmulationState[browser.id] = emulationState
+        }
+      }
     }
   }
 
   override fun update(e: AnActionEvent) {
     super.update(e)
     val project = e.project
-    val browser = project?.let { getCurrentBrowser(it) }
+    val browser = project?.let { GBrowserMobileToggleActionUtils.getCurrentBrowser(it) }
 
     LOG.debug("GBrowserMobileToggleAction: update - project: ${project != null}, browser: ${browser?.id}")
 
@@ -167,502 +150,6 @@ class GBrowserMobileToggleAction : ToggleAction(
       }
       e.presentation.text = text
       LOG.debug("GBrowserMobileToggleAction: update - text: $text, state active: $isActive, device: $currentDevice")
-    }
-  }
-
-  private fun enableDeviceEmulation(browserPanel: SimpleToolWindowPanel, browser: GCefBrowser) {
-    val state = synchronized(stateLock) {
-      val s = deviceEmulationState.getOrPut(browser.id) { DeviceEmulationState() }
-      if (s.isActive) return
-      s.isActive = true
-      s
-    }
-
-    LOG.info("GBrowserMobileToggleAction: Enabling device emulation for browser ${browser.id}")
-
-    // Create device toolbar
-    state.deviceToolbar = createDeviceToolbar(browser)
-
-    // Create browser wrapper with padding - use Chrome DevTools colors
-    val project = browser.project
-    val isDarkTheme = GBrowserThemeUtil.isDarkTheme(project)
-    state.browserWrapper = JBPanel<JBPanel<*>>(GridBagLayout()).apply {
-      // Use Chrome DevTools colors based on theme
-      background = if (isDarkTheme) {
-        CHROME_DEVTOOLS_DARK_BG
-      } else {
-        CHROME_DEVTOOLS_LIGHT_BG
-      }
-      border = JBUI.Borders.empty(20)
-    }
-
-    // Create a container panel
-    val deviceToolbar = state.deviceToolbar ?: return
-    val browserWrapper = state.browserWrapper ?: return
-    
-    val containerPanel = JBPanel<JBPanel<*>>(BorderLayout()).apply {
-      add(deviceToolbar, BorderLayout.NORTH)
-      add(browserWrapper, BorderLayout.CENTER)
-    }
-
-    // Replace the content
-    browserPanel.setContent(containerPanel)
-
-    // Apply initial responsive mode
-    applyResponsiveMode(browser, state)
-
-    browserPanel.revalidate()
-    browserPanel.repaint()
-
-    // Ensure device frame update happens after layout is complete
-    // Use invokeAndWait to avoid race conditions
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeAndWait {
-        commonUpdate(browser, state)
-      }
-    } else {
-      // If already on EDT, schedule for next cycle to ensure layout is complete
-      SwingUtilities.invokeLater {
-        commonUpdate(browser, state)
-      }
-    }
-
-
-  }
-
-  private fun commonUpdate(browser: GCefBrowser, state: DeviceEmulationState) {
-    LOG.debug("GBrowserMobileToggleAction: Updating device frame after layout")
-    updateDeviceFrame(browser, state)
-  }
-
-  private fun disableDeviceEmulation(browserPanel: SimpleToolWindowPanel, browser: GCefBrowser) {
-    val state = synchronized(stateLock) {
-      val s = deviceEmulationState[browser.id] ?: return
-      if (!s.isActive) return
-      s.isActive = false
-      s
-    }
-
-    LOG.info("GBrowserMobileToggleAction: Disabling device emulation for browser ${browser.id}")
-
-    // Clean up UI components properly before nulling references
-    synchronized(stateLock) {
-      // Remove browser from wrapper to prevent memory leaks
-      state.browserWrapper?.removeAll()
-      state.deviceToolbar?.removeAll()
-
-      state.currentDevice = null
-      state.deviceToolbar = null
-      state.browserWrapper = null
-      state.isRotated = false
-      state.currentWidth = DEFAULT_RESPONSIVE_WIDTH
-      state.currentHeight = DEFAULT_RESPONSIVE_HEIGHT
-    }
-
-    // Reset browser emulation
-    GBrowserDeviceEmulationUtil.resetDeviceEmulation(browser.cefBrowser)
-
-    // Reset zoom level to 100%
-    browser.cefBrowser.zoomLevel = 0.0
-
-    // Remove browser component from wrapper first to avoid duplicate parent issues
-    state.browserWrapper?.remove(browser.component)
-    
-    // Restore original browser component
-    browserPanel.setContent(browser.component)
-
-    browserPanel.revalidate()
-    browserPanel.repaint()
-
-    // Force a reload to ensure all changes are applied
-    browser.cefBrowser.reload()
-  }
-
-  private fun createDeviceToolbar(browser: GCefBrowser): JPanel {
-    val state = synchronized(stateLock) {
-      deviceEmulationState[browser.id] ?: throw IllegalStateException("Device emulation state wasn't found for browser ${browser.id}")
-    }
-
-    val deviceComboBox = ComboBox<String>().apply {
-      // Add "Responsive" as default
-      addItem("Responsive")
-
-      // Add all device profiles
-      GBrowserDeviceEmulationUtil.DEVICE_PROFILES.keys.forEach { deviceName ->
-        addItem(deviceName)
-      }
-
-      // Add action listener
-      addActionListener { _ ->
-        when (val selected = selectedItem as? String) {
-          "Responsive" -> {
-            LOG.info("GBrowserMobileToggleAction: Selected Responsive mode")
-            applyResponsiveMode(browser, state)
-          }
-          null -> {
-            LOG.info("GBrowserMobileToggleAction: No device selected")
-          }
-          else -> {
-            LOG.info("GBrowserMobileToggleAction: Selected device: $selected")
-            GBrowserDeviceEmulationUtil.DEVICE_PROFILES[selected]?.let { profile ->
-              applyDeviceProfile(browser, profile, state)
-            }
-          }
-        }
-      }
-    }
-
-    // Width spinner
-    val widthSpinner = JSpinner(SpinnerNumberModel(state.currentWidth, 50, 9999, 1)).apply {
-      name = "widthSpinner"
-      preferredSize = Dimension(80, preferredSize.height)
-      addChangeListener {
-        val newWidth = value as Int
-        if (state.currentWidth != newWidth) {
-          LOG.debug("GBrowserMobileToggleAction: Width changed from ${state.currentWidth} to $newWidth")
-          state.currentWidth = newWidth
-          updateDeviceSize(browser, state)
-        }
-      }
-    }
-
-    // Height spinner
-    val heightSpinner = JSpinner(SpinnerNumberModel(state.currentHeight, 50, 9999, 1)).apply {
-      name = "heightSpinner"
-      preferredSize = Dimension(80, preferredSize.height)
-      addChangeListener {
-        val newHeight = value as Int
-        if (state.currentHeight != newHeight) {
-          LOG.debug("GBrowserMobileToggleAction: Height changed from ${state.currentHeight} to $newHeight")
-          state.currentHeight = newHeight
-          updateDeviceSize(browser, state)
-        }
-      }
-    }
-
-    // Zoom combo box
-    val zoomComboBox = ComboBox(arrayOf("50%", "75%", "100%", "125%", "150%")).apply {
-      selectedItem = "100%"
-      isEditable = true
-      preferredSize = Dimension(80, preferredSize.height)
-      addActionListener {
-        val zoomText = selectedItem as? String ?: return@addActionListener
-        val zoomValue = zoomText.removeSuffix("%").toDoubleOrNull() ?: return@addActionListener
-        val zoom = zoomValue / 100.0
-        val zoomLevel = ln(zoom) / ln(ZOOM_FACTOR)
-        LOG.debug("GBrowserMobileToggleAction: Zoom changed to $zoomText, zoom level: $zoomLevel")
-        browser.cefBrowser.zoomLevel = zoomLevel
-      }
-    }
-
-
-    // Rotate button
-    val rotateButton = JButton(AllIcons.Actions.SyncPanels).apply {
-      toolTipText = "Rotate"
-      preferredSize = Dimension(30, 26)
-      addActionListener {
-        state.isRotated = !state.isRotated
-        // Swap width and height
-        val temp = state.currentWidth
-        state.currentWidth = state.currentHeight
-        state.currentHeight = temp
-
-        LOG.debug("GBrowserMobileToggleAction: Rotated device - new dimensions: ${state.currentWidth}x${state.currentHeight}")
-
-        // Update spinners
-        widthSpinner.value = state.currentWidth
-        heightSpinner.value = state.currentHeight
-
-        // Update device
-        updateDeviceSize(browser, state)
-      }
-    }
-
-    return JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 5, 2)).apply {
-      // Match Chrome DevTools toolbar styling
-      val isDarkTheme = GBrowserThemeUtil.isDarkTheme(browser.project)
-      background = if (isDarkTheme) {
-        JBColor(Color(0x2B2D30), Color(0x2B2D30)) // Chrome DevTools toolbar dark background
-      } else {
-        JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome DevTools toolbar light background  
-      }
-      border = JBUI.Borders.compound(
-        JBUI.Borders.customLine(
-          if (isDarkTheme) JBColor(Color(0x393B3F), Color(0x393B3F)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
-          0, 0, 1, 0
-        ),
-        JBUI.Borders.empty(5, 10)
-      )
-
-      // Device selector
-      add(deviceComboBox)
-
-      // Size controls
-      add(Box.createHorizontalStrut(10))
-      add(widthSpinner)
-      add(JBLabel("×").apply {
-        border = JBUI.Borders.empty(0, 3)
-      })
-      add(heightSpinner)
-
-      // Zoom controls
-      add(Box.createHorizontalStrut(10))
-      add(zoomComboBox)
-      add(JBLabel("%"))
-
-      // Action buttons
-      add(Box.createHorizontalStrut(10))
-      add(rotateButton)
-    }
-  }
-
-  private fun applyResponsiveMode(browser: GCefBrowser, state: DeviceEmulationState) {
-    state.currentDevice = "Responsive"
-
-    // Set default responsive size
-    if (state.currentWidth == 0 || state.currentHeight == 0) {
-      state.currentWidth = 400
-      state.currentHeight = 626
-    }
-
-    LOG.info("GBrowserMobileToggleAction: Applying responsive mode with dimensions ${state.currentWidth}x${state.currentHeight}")
-
-    // Update the device frame with responsive dimensions
-    updateDeviceFrame(browser, state)
-
-    // Update spinners
-    updateSpinnersFromState(state)
-
-    // Reset any device-specific emulation
-    GBrowserDeviceEmulationUtil.resetDeviceEmulation(browser.cefBrowser)
-
-    // Apply responsive mode with custom dimensions
-    val responsiveProfile = DeviceProfile(
-      name = "Responsive",
-      width = state.currentWidth,
-      height = state.currentHeight,
-      deviceScaleFactor = 1.0,
-      userAgent = browser.cefBrowser.url?.let {
-        // Use a mobile user agent for responsive mode
-        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
-      } ?: "",
-      isMobile = true,
-      hasTouch = true
-    )
-
-    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, responsiveProfile)
-
-    state.browserWrapper?.revalidate()
-    state.browserWrapper?.repaint()
-  }
-
-  private fun applyDeviceProfile(browser: GCefBrowser, profile: DeviceProfile, state: DeviceEmulationState) {
-    state.currentDevice = profile.name
-    state.currentWidth = profile.width
-    state.currentHeight = profile.height
-    state.isRotated = false
-
-    LOG.info("GBrowserMobileToggleAction: Applying device profile '${profile.name}' with dimensions ${profile.width}x${profile.height}")
-
-    // Update browser wrapper to show device frame first
-    updateDeviceFrame(browser, state)
-
-    // Update spinners
-    updateSpinnersFromState(state)
-
-    // Apply JavaScript emulation after frame is set
-    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, profile)
-
-    // Reload the page to apply all changes
-    browser.cefBrowser.reload()
-
-    state.browserWrapper?.revalidate()
-    state.browserWrapper?.repaint()
-  }
-
-  private fun getCurrentBrowser(project: Project): GCefBrowser? {
-    LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - looking for browser in the project")
-
-    // First try to get from the regular browser window
-    val browserPanel = GBrowserToolWindowUtil.getSelectedBrowserPanel(project)
-    if (browserPanel != null) {
-      val browser = browserPanel.getBrowser()
-      LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - found browser in the main panel: ${browser.id}")
-      return browser
-    }
-
-    // If not found, try to get from DevTools window
-    val toolWindowManager = project.getService(com.intellij.openapi.wm.ToolWindowManager::class.java)
-    val devToolsWindow = toolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID)
-    val selectedContent = devToolsWindow?.contentManager?.selectedContent
-    val devToolsPanel = selectedContent?.component as? com.github.gbrowser.ui.toolwindow.dev_tools.GBrowserToolWindowDevTools
-
-    val devBrowser = devToolsPanel?.browser
-    LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - devtools browser: ${devBrowser?.id}")
-    return devBrowser
-  }
-
-  private fun getBrowserPanel(project: Project): SimpleToolWindowPanel? {
-    LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - looking for the browser panel")
-
-    // Get the browser tool window panel directly - it should be a SimpleToolWindowPanel
-    val browserPanel = GBrowserToolWindowUtil.getSelectedBrowserPanel(project)
-    if (browserPanel is SimpleToolWindowPanel) {
-      LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - found the main browser panel")
-      return browserPanel
-    }
-
-    // If not found, try to get from DevTools window
-    val toolWindowManager = project.getService(com.intellij.openapi.wm.ToolWindowManager::class.java)
-    val devToolsWindow = toolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID)
-    val selectedContent = devToolsWindow?.contentManager?.selectedContent
-    val devToolsPanel = selectedContent?.component
-
-    if (devToolsPanel is SimpleToolWindowPanel) {
-      LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - found devtools panel")
-      return devToolsPanel
-    }
-
-    LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - no panel found")
-    return null
-  }
-
-  private fun updateSpinnersFromState(state: DeviceEmulationState) {
-    state.deviceToolbar?.components?.forEach { component ->
-      if (component is JSpinner) {
-        when (component.name) {
-          "widthSpinner" -> {
-            LOG.debug("GBrowserMobileToggleAction: Setting width spinner to ${state.currentWidth}")
-            component.value = state.currentWidth
-          }
-          "heightSpinner" -> {
-            LOG.debug("GBrowserMobileToggleAction: Setting height spinner to ${state.currentHeight}")
-            component.value = state.currentHeight
-          }
-        }
-      }
-    }
-  }
-
-  private fun updateDeviceSize(browser: GCefBrowser, state: DeviceEmulationState) {
-    LOG.debug("GBrowserMobileToggleAction: updateDeviceSize - ${state.currentWidth}x${state.currentHeight}")
-
-    // Create custom device profile with current dimensions
-    val customProfile = DeviceProfile(
-      name = "Custom",
-      width = state.currentWidth,
-      height = state.currentHeight,
-      deviceScaleFactor = 1.0,
-      userAgent = browser.cefBrowser.url?.let {
-        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
-      } ?: ""
-    )
-
-    // Apply the custom profile
-    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, customProfile)
-
-    // Update the frame
-    updateDeviceFrame(browser, state)
-  }
-
-  private fun updateDeviceFrame(browser: GCefBrowser, state: DeviceEmulationState) {
-    state.browserWrapper?.let { wrapper ->
-      wrapper.removeAll()
-
-      // Get available space in the wrapper (accounting for padding)
-      val wrapperWidth = wrapper.width
-      val wrapperHeight = wrapper.height
-
-      // If wrapper dimensions are not yet set, use the device dimensions as-is
-      if (wrapperWidth <= 40 || wrapperHeight <= 40) {
-        LOG.info("GBrowserMobileToggleAction: Wrapper dimensions not ready ($wrapperWidth x $wrapperHeight), using device dimensions as-is")
-        updateDeviceFrameWithDimensions(browser, state, state.currentWidth, state.currentHeight, 1.0)
-        return
-      }
-
-      val availableWidth = wrapperWidth - 40 // 20px padding on each side
-      val availableHeight = wrapperHeight - 40 // 20px padding on top/bottom
-
-      // Calculate scale if the device is too large
-      var deviceWidth = state.currentWidth
-      var deviceHeight = state.currentHeight
-      var scale = 1.0
-
-      if (deviceWidth > availableWidth || deviceHeight > availableHeight) {
-        val scaleX = availableWidth.toDouble() / deviceWidth
-        val scaleY = availableHeight.toDouble() / deviceHeight
-        scale = minOf(scaleX, scaleY, 1.0) // Never scale up, only down
-
-        // Apply scale with some margin
-        scale *= 0.9 // 90% to ensure some padding
-        deviceWidth = (state.currentWidth * scale).toInt()
-        deviceHeight = (state.currentHeight * scale).toInt()
-      }
-
-      LOG.info("GBrowserMobileToggleAction: Updating device frame - Original: ${state.currentWidth}x${state.currentHeight}, Scaled: ${deviceWidth}x${deviceHeight} (scale: $scale)")
-
-      updateDeviceFrameWithDimensions(browser, state, deviceWidth, deviceHeight, scale)
-    }
-  }
-
-  private fun updateDeviceFrameWithDimensions(browser: GCefBrowser, state: DeviceEmulationState, deviceWidth: Int, deviceHeight: Int, scale: Double) {
-    state.browserWrapper?.let { wrapper ->
-      // Get project from browser
-      val project = browser.project
-
-      // Create device frame panel
-      val deviceFrame = JBPanel<JBPanel<*>>(BorderLayout()).apply {
-        preferredSize = Dimension(deviceWidth, deviceHeight)
-        minimumSize = preferredSize
-        maximumSize = preferredSize
-
-        // Match Chrome DevTools styling
-        val isDarkTheme = GBrowserThemeUtil.isDarkTheme(project)
-        background = if (isDarkTheme) {
-          JBColor(Color(0x292A2D), Color(0x292A2D)) // Slightly lighter than the wrapper for contrast
-        } else {
-          JBColor(Color(0xFFFFFF), Color(0xFFFFFF)) // White for light theme
-        }
-        border = BorderFactory.createCompoundBorder(
-          BorderFactory.createLineBorder(
-            if (isDarkTheme) JBColor(Color(0x3C3F41), Color(0x3C3F41)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
-            1
-          ),
-          BorderFactory.createEmptyBorder(2, 2, 2, 2) // Small inner padding
-        )
-
-        // Ensure browser component respects the scaled device frame size
-        browser.component.preferredSize = Dimension(deviceWidth, deviceHeight)
-        browser.component.minimumSize = Dimension(deviceWidth, deviceHeight)
-        browser.component.maximumSize = Dimension(deviceWidth, deviceHeight)
-
-        // Add the browser component
-        add(browser.component, BorderLayout.CENTER)
-      }
-
-      val constraints = GridBagConstraints().apply {
-        gridx = 0
-        gridy = 0
-        anchor = GridBagConstraints.CENTER
-      }
-
-      wrapper.add(deviceFrame, constraints)
-      wrapper.revalidate()
-      wrapper.repaint()
-
-      // Force browser to recognize the new size
-      browser.component.revalidate()
-      // Use original dimensions for the browser viewport, not scaled dimensions
-      browser.cefBrowser.wasResized(state.currentWidth, state.currentHeight)
-
-      // Apply zoom if scaled
-      if (scale < 1.0) {
-        val zoomLevel = ln(scale) / ln(1.2)
-        browser.cefBrowser.zoomLevel = zoomLevel
-        LOG.info("GBrowserMobileToggleAction: Applied zoom level $zoomLevel for scale $scale")
-      }
-
-      LOG.info("GBrowserMobileToggleAction: Device frame updated and browser resized")
     }
   }
 }

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleAction.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleAction.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.DumbAware
+import java.util.*
 
 class GBrowserMobileToggleAction : ToggleAction(
   GBrowserBundle.message("action.GBrowserMobileToggleAction.text"),
@@ -14,10 +15,18 @@ class GBrowserMobileToggleAction : ToggleAction(
   com.github.gbrowser.GBrowserIcons.TOGGLE_DEVICES
 ), DumbAware {
 
+  /**
+   * Companion object for GBrowserMobileToggleAction.
+   * @Suppress("CompanionObjectInExtension") is used because we need static state management
+   * for device emulation across multiple browser instances.
+   */
   @Suppress("CompanionObjectInExtension")
   companion object {
     private val LOG = thisLogger()
-    private val deviceEmulationState = mutableMapOf<String, DeviceEmulationState>()
+
+    // Use WeakHashMap to prevent memory leaks - entries are automatically removed
+    // when the browser ID (key) is no longer strongly referenced elsewhere
+    private val deviceEmulationState = Collections.synchronizedMap(WeakHashMap<String, DeviceEmulationState>())
     private val stateLock = Any() // Lock for synchronizing state access
     
 

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
@@ -16,10 +16,6 @@ import javax.swing.SwingUtilities
 object GBrowserMobileToggleActionHelper {
   private val LOG = thisLogger()
 
-  // Chrome DevTools colors - matching the actual Chrome DevTools colors
-  private val CHROME_DEVTOOLS_DARK_BG = JBColor(Color(0x202124), Color(0x202124)) // Chrome's actual dark background (lighter gray)
-  private val CHROME_DEVTOOLS_LIGHT_BG = JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome's actual light background
-
   fun enableDeviceEmulation(
     browserPanel: SimpleToolWindowPanel,
     browser: GCefBrowser,
@@ -36,11 +32,11 @@ object GBrowserMobileToggleActionHelper {
     state.browserWrapper = JBPanel<JBPanel<*>>(GridBagLayout()).apply {
       // Use Chrome DevTools colors based on theme
       background = if (isDarkTheme) {
-        CHROME_DEVTOOLS_DARK_BG
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVTOOLS_DARK_BG), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_DARK_BG))
       } else {
-        CHROME_DEVTOOLS_LIGHT_BG
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVTOOLS_LIGHT_BG), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_LIGHT_BG))
       }
-      border = JBUI.Borders.empty(20)
+      border = JBUI.Borders.empty(DeviceEmulationConstants.DEVICE_FRAME_PADDING_HALF)
     }
 
     // Create a container panel
@@ -62,16 +58,10 @@ object GBrowserMobileToggleActionHelper {
     browserPanel.repaint()
 
     // Ensure device frame update happens after layout is complete
-    // Use invokeAndWait to avoid race conditions
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeAndWait {
-        commonUpdate(browser, state)
-      }
-    } else {
-      // If already on EDT, schedule for next cycle to ensure layout is complete
-      SwingUtilities.invokeLater {
-        commonUpdate(browser, state)
-      }
+    // Always use invokeLater to avoid potential deadlocks and ensure consistent behavior
+    // This guarantees the update runs after the current EDT event completes
+    SwingUtilities.invokeLater {
+      commonUpdate(browser, state)
     }
   }
 

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
@@ -87,8 +87,8 @@ object GBrowserMobileToggleActionHelper {
     state.deviceToolbar = null
     state.browserWrapper = null
     state.isRotated = false
-    state.currentWidth = DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH
-    state.currentHeight = DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT
+    state.currentWidth = DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH
+    state.currentHeight = DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT
 
     // Reset browser emulation
     GBrowserDeviceEmulationUtil.resetDeviceEmulation(browser.cefBrowser)
@@ -96,8 +96,6 @@ object GBrowserMobileToggleActionHelper {
     // Reset zoom level to 100%
     browser.cefBrowser.zoomLevel = 0.0
 
-    // Remove browser component from wrapper first to avoid duplicate parent issues
-    state.browserWrapper?.remove(browser.component)
 
     // Restore original browser component
     browserPanel.setContent(browser.component)

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionHelper.kt
@@ -1,0 +1,124 @@
+package com.github.gbrowser.actions
+
+import com.github.gbrowser.ui.gcef.GCefBrowser
+import com.github.gbrowser.util.GBrowserDeviceEmulationUtil
+import com.github.gbrowser.util.GBrowserThemeUtil
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBPanel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.GridBagLayout
+import javax.swing.SwingUtilities
+
+object GBrowserMobileToggleActionHelper {
+  private val LOG = thisLogger()
+
+  // Chrome DevTools colors - matching the actual Chrome DevTools colors
+  private val CHROME_DEVTOOLS_DARK_BG = JBColor(Color(0x202124), Color(0x202124)) // Chrome's actual dark background (lighter gray)
+  private val CHROME_DEVTOOLS_LIGHT_BG = JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome's actual light background
+
+  fun enableDeviceEmulation(
+    browserPanel: SimpleToolWindowPanel,
+    browser: GCefBrowser,
+    state: DeviceEmulationState
+  ) {
+    LOG.info("GBrowserMobileToggleAction: Enabling device emulation for browser ${browser.id}")
+
+    // Create device toolbar
+    state.deviceToolbar = GBrowserMobileToggleActionUI.createDeviceToolbar(browser, state)
+
+    // Create browser wrapper with padding - use Chrome DevTools colors
+    val project = browser.project
+    val isDarkTheme = GBrowserThemeUtil.isDarkTheme(project)
+    state.browserWrapper = JBPanel<JBPanel<*>>(GridBagLayout()).apply {
+      // Use Chrome DevTools colors based on theme
+      background = if (isDarkTheme) {
+        CHROME_DEVTOOLS_DARK_BG
+      } else {
+        CHROME_DEVTOOLS_LIGHT_BG
+      }
+      border = JBUI.Borders.empty(20)
+    }
+
+    // Create a container panel
+    val deviceToolbar = state.deviceToolbar ?: return
+    val browserWrapper = state.browserWrapper ?: return
+
+    val containerPanel = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+      add(deviceToolbar, BorderLayout.NORTH)
+      add(browserWrapper, BorderLayout.CENTER)
+    }
+
+    // Replace the content
+    browserPanel.setContent(containerPanel)
+
+    // Apply initial responsive mode
+    GBrowserMobileToggleActionUI.applyResponsiveMode(browser, state)
+
+    browserPanel.revalidate()
+    browserPanel.repaint()
+
+    // Ensure device frame update happens after layout is complete
+    // Use invokeAndWait to avoid race conditions
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeAndWait {
+        commonUpdate(browser, state)
+      }
+    } else {
+      // If already on EDT, schedule for next cycle to ensure layout is complete
+      SwingUtilities.invokeLater {
+        commonUpdate(browser, state)
+      }
+    }
+  }
+
+  private fun commonUpdate(browser: GCefBrowser, state: DeviceEmulationState) {
+    LOG.debug("GBrowserMobileToggleAction: Updating device frame after layout")
+    GBrowserMobileToggleActionUI.updateDeviceFrame(browser, state)
+  }
+
+  fun disableDeviceEmulation(
+    browserPanel: SimpleToolWindowPanel,
+    browser: GCefBrowser,
+    state: DeviceEmulationState,
+    onCleanup: () -> Unit
+  ) {
+    LOG.info("GBrowserMobileToggleAction: Disabling device emulation for browser ${browser.id}")
+
+    // Clean up UI components properly before nulling references
+    // Remove browser from wrapper to prevent memory leaks
+    state.browserWrapper?.also { it.removeAll() }
+    state.deviceToolbar?.also { it.removeAll() }
+
+    state.currentDevice = null
+    state.deviceToolbar = null
+    state.browserWrapper = null
+    state.isRotated = false
+    state.currentWidth = DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH
+    state.currentHeight = DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT
+
+    // Reset browser emulation
+    GBrowserDeviceEmulationUtil.resetDeviceEmulation(browser.cefBrowser)
+
+    // Reset zoom level to 100%
+    browser.cefBrowser.zoomLevel = 0.0
+
+    // Remove browser component from wrapper first to avoid duplicate parent issues
+    state.browserWrapper?.remove(browser.component)
+
+    // Restore original browser component
+    browserPanel.setContent(browser.component)
+
+    browserPanel.revalidate()
+    browserPanel.repaint()
+
+    // Force a reload to ensure all changes are applied
+    browser.cefBrowser.reload()
+
+    // Call cleanup callback
+    onCleanup()
+  }
+}

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionState.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionState.kt
@@ -1,0 +1,22 @@
+package com.github.gbrowser.actions
+
+import com.intellij.ui.components.JBPanel
+import javax.swing.JPanel
+
+/**
+ * Represents the state of device emulation for a browser.
+ */
+data class DeviceEmulationState(
+  var isActive: Boolean = false,
+  var currentDevice: String? = null,
+  var deviceToolbar: JPanel? = null,
+  var browserWrapper: JBPanel<JBPanel<*>>? = null,
+  var isRotated: Boolean = false,
+  var currentWidth: Int = DEFAULT_RESPONSIVE_WIDTH,
+  var currentHeight: Int = DEFAULT_RESPONSIVE_HEIGHT
+) {
+  companion object {
+    const val DEFAULT_RESPONSIVE_WIDTH = 400
+    const val DEFAULT_RESPONSIVE_HEIGHT = 626
+  }
+}

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionState.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionState.kt
@@ -12,11 +12,6 @@ data class DeviceEmulationState(
   var deviceToolbar: JPanel? = null,
   var browserWrapper: JBPanel<JBPanel<*>>? = null,
   var isRotated: Boolean = false,
-  var currentWidth: Int = DEFAULT_RESPONSIVE_WIDTH,
-  var currentHeight: Int = DEFAULT_RESPONSIVE_HEIGHT
-) {
-  companion object {
-    const val DEFAULT_RESPONSIVE_WIDTH = 400
-    const val DEFAULT_RESPONSIVE_HEIGHT = 626
-  }
-}
+  var currentWidth: Int = DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH,
+  var currentHeight: Int = DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT
+) 

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
@@ -25,40 +25,44 @@ object GBrowserMobileToggleActionUI {
     val zoomComboBox = createZoomComboBox(browser)
     val rotateButton = createRotateButton(browser, state, widthSpinner, heightSpinner)
 
-    return JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 5, 2)).apply {
+    return JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, DeviceEmulationConstants.TOOLBAR_HORIZONTAL_GAP, DeviceEmulationConstants.TOOLBAR_VERTICAL_GAP)).apply {
       // Match Chrome DevTools toolbar styling
       val isDarkTheme = GBrowserThemeUtil.isDarkTheme(browser.project)
       background = if (isDarkTheme) {
-        JBColor(Color(0x2B2D30), Color(0x2B2D30)) // Chrome DevTools toolbar dark background
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVTOOLS_TOOLBAR_DARK_BG), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_TOOLBAR_DARK_BG))
       } else {
-        JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome DevTools toolbar light background  
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVTOOLS_TOOLBAR_LIGHT_BG), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_TOOLBAR_LIGHT_BG))
       }
       border = JBUI.Borders.compound(
         JBUI.Borders.customLine(
-          if (isDarkTheme) JBColor(Color(0x393B3F), Color(0x393B3F)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
+          if (isDarkTheme) JBColor(Color(DeviceEmulationConstants.CHROME_DEVTOOLS_DARK_BORDER), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_DARK_BORDER)) else JBColor(
+            Color(
+              DeviceEmulationConstants.CHROME_DEVTOOLS_LIGHT_BORDER
+            ), Color(DeviceEmulationConstants.CHROME_DEVTOOLS_LIGHT_BORDER)
+          ),
           0, 0, 1, 0
         ),
-        JBUI.Borders.empty(5, 10)
+        JBUI.Borders.empty(DeviceEmulationConstants.TOOLBAR_PADDING, DeviceEmulationConstants.TOOLBAR_HORIZONTAL_PADDING)
       )
 
       // Device selector
       add(deviceComboBox)
 
       // Size controls
-      add(Box.createHorizontalStrut(10))
+      add(Box.createHorizontalStrut(DeviceEmulationConstants.HORIZONTAL_STRUT_SIZE))
       add(widthSpinner)
       add(JBLabel("×").apply {
-        border = JBUI.Borders.empty(0, 3)
+        border = JBUI.Borders.empty(0, DeviceEmulationConstants.LABEL_HORIZONTAL_PADDING)
       })
       add(heightSpinner)
 
       // Zoom controls
-      add(Box.createHorizontalStrut(10))
+      add(Box.createHorizontalStrut(DeviceEmulationConstants.HORIZONTAL_STRUT_SIZE))
       add(zoomComboBox)
       add(JBLabel("%"))
 
       // Action buttons
-      add(Box.createHorizontalStrut(10))
+      add(Box.createHorizontalStrut(DeviceEmulationConstants.HORIZONTAL_STRUT_SIZE))
       add(rotateButton)
     }
   }
@@ -95,9 +99,16 @@ object GBrowserMobileToggleActionUI {
   }
 
   private fun createWidthSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
-    return JSpinner(SpinnerNumberModel(state.currentWidth, 50, 9999, 1)).apply {
-      name = "device-width-spinner"
-      preferredSize = Dimension(80, preferredSize.height)
+    return JSpinner(
+      SpinnerNumberModel(
+        state.currentWidth,
+        DeviceEmulationConstants.MIN_DEVICE_DIMENSION,
+        DeviceEmulationConstants.MAX_DEVICE_DIMENSION,
+        DeviceEmulationConstants.DIMENSION_STEP
+      )
+    ).apply {
+      name = DeviceEmulationConstants.DEVICE_WIDTH_SPINNER_NAME
+      preferredSize = Dimension(DeviceEmulationConstants.SPINNER_WIDTH, preferredSize.height)
       addChangeListener {
         val newWidth = value as Int
         if (state.currentWidth != newWidth) {
@@ -110,9 +121,16 @@ object GBrowserMobileToggleActionUI {
   }
 
   private fun createHeightSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
-    return JSpinner(SpinnerNumberModel(state.currentHeight, 50, 9999, 1)).apply {
-      name = "device-height-spinner"
-      preferredSize = Dimension(80, preferredSize.height)
+    return JSpinner(
+      SpinnerNumberModel(
+        state.currentHeight,
+        DeviceEmulationConstants.MIN_DEVICE_DIMENSION,
+        DeviceEmulationConstants.MAX_DEVICE_DIMENSION,
+        DeviceEmulationConstants.DIMENSION_STEP
+      )
+    ).apply {
+      name = DeviceEmulationConstants.DEVICE_HEIGHT_SPINNER_NAME
+      preferredSize = Dimension(DeviceEmulationConstants.SPINNER_WIDTH, preferredSize.height)
       addChangeListener {
         val newHeight = value as Int
         if (state.currentHeight != newHeight) {
@@ -126,14 +144,14 @@ object GBrowserMobileToggleActionUI {
 
   private fun createZoomComboBox(browser: GCefBrowser): ComboBox<String> {
     return ComboBox(arrayOf("50%", "75%", "100%", "125%", "150%")).apply {
-      selectedItem = "100%"
+      selectedItem = DeviceEmulationConstants.DEFAULT_ZOOM_PERCENTAGE
       isEditable = true
-      preferredSize = Dimension(80, preferredSize.height)
+      preferredSize = Dimension(DeviceEmulationConstants.SPINNER_WIDTH, preferredSize.height)
       addActionListener {
         val zoomText = selectedItem as? String ?: return@addActionListener
         val zoomValue = zoomText.removeSuffix("%").toDoubleOrNull() ?: return@addActionListener
         val zoom = zoomValue / 100.0
-        val zoomLevel = ln(zoom) / ln(1.2)
+        val zoomLevel = ln(zoom) / ln(DeviceEmulationConstants.ZOOM_FACTOR)
         LOG.debug("GBrowserMobileToggleAction: Zoom changed to $zoomText, zoom level: $zoomLevel")
         browser.cefBrowser.zoomLevel = zoomLevel
       }
@@ -148,7 +166,7 @@ object GBrowserMobileToggleActionUI {
   ): JButton {
     return JButton(AllIcons.Actions.SyncPanels).apply {
       toolTipText = "Rotate"
-      preferredSize = Dimension(30, 26)
+      preferredSize = Dimension(DeviceEmulationConstants.ROTATE_BUTTON_WIDTH, DeviceEmulationConstants.ROTATE_BUTTON_HEIGHT)
       addActionListener {
         state.isRotated = !state.isRotated
         // Swap width and height
@@ -196,7 +214,7 @@ object GBrowserMobileToggleActionUI {
       deviceScaleFactor = 1.0,
       userAgent = browser.cefBrowser.url?.let {
         // Use a mobile user agent for responsive mode
-        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+        DeviceEmulationConstants.MOBILE_USER_AGENT_ANDROID
       } ?: "",
       isMobile = true,
       hasTouch = true
@@ -241,14 +259,14 @@ object GBrowserMobileToggleActionUI {
     val wrapperHeight = wrapper.height
 
     // If wrapper dimensions are not yet set, use the device dimensions as-is
-    if (wrapperWidth <= 40 || wrapperHeight <= 40) {
+    if (wrapperWidth <= DeviceEmulationConstants.DEVICE_FRAME_PADDING || wrapperHeight <= DeviceEmulationConstants.DEVICE_FRAME_PADDING) {
       LOG.info("GBrowserMobileToggleAction: Wrapper dimensions not ready ($wrapperWidth x $wrapperHeight), using device dimensions as-is")
       updateDeviceFrameWithDimensions(browser, state, state.currentWidth, state.currentHeight, 1.0)
       return
     }
 
-    val availableWidth = wrapperWidth - 40 // 20px padding on each side
-    val availableHeight = wrapperHeight - 40 // 20px padding on top/bottom
+    val availableWidth = wrapperWidth - DeviceEmulationConstants.DEVICE_FRAME_PADDING
+    val availableHeight = wrapperHeight - DeviceEmulationConstants.DEVICE_FRAME_PADDING
 
     // Calculate scale if the device is too large
     var deviceWidth = state.currentWidth
@@ -261,7 +279,7 @@ object GBrowserMobileToggleActionUI {
       scale = minOf(scaleX, scaleY, 1.0) // Never scale up, only down
 
       // Apply scale with some margin
-      scale *= 0.9 // 90% to ensure some padding
+      scale *= DeviceEmulationConstants.SCALE_PADDING_FACTOR
       deviceWidth = (state.currentWidth * scale).toInt()
       deviceHeight = (state.currentHeight * scale).toInt()
     }
@@ -275,11 +293,11 @@ object GBrowserMobileToggleActionUI {
     state.deviceToolbar?.components?.forEach { component ->
       if (component is JSpinner) {
         when (component.name) {
-          "device-width-spinner" -> {
+          DeviceEmulationConstants.DEVICE_WIDTH_SPINNER_NAME -> {
             LOG.debug("GBrowserMobileToggleAction: Setting width spinner to ${state.currentWidth}")
             component.value = state.currentWidth
           }
-          "device-height-spinner" -> {
+          DeviceEmulationConstants.DEVICE_HEIGHT_SPINNER_NAME -> {
             LOG.debug("GBrowserMobileToggleAction: Setting height spinner to ${state.currentHeight}")
             component.value = state.currentHeight
           }
@@ -298,7 +316,7 @@ object GBrowserMobileToggleActionUI {
       height = state.currentHeight,
       deviceScaleFactor = 1.0,
       userAgent = browser.cefBrowser.url?.let {
-        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+        DeviceEmulationConstants.MOBILE_USER_AGENT_ANDROID
       } ?: ""
     )
 
@@ -323,16 +341,24 @@ object GBrowserMobileToggleActionUI {
       // Match Chrome DevTools styling
       val isDarkTheme = GBrowserThemeUtil.isDarkTheme(project)
       background = if (isDarkTheme) {
-        JBColor(Color(0x292A2D), Color(0x292A2D)) // Slightly lighter than the wrapper for contrast
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_DARK_BG), Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_DARK_BG))
       } else {
-        JBColor(Color(0xFFFFFF), Color(0xFFFFFF)) // White for light theme
+        JBColor(Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_LIGHT_BG), Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_LIGHT_BG))
       }
       border = BorderFactory.createCompoundBorder(
         BorderFactory.createLineBorder(
-          if (isDarkTheme) JBColor(Color(0x3C3F41), Color(0x3C3F41)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
+          if (isDarkTheme) JBColor(Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_DARK_BORDER), Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_DARK_BORDER)) else JBColor(
+            Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_LIGHT_BORDER),
+            Color(DeviceEmulationConstants.CHROME_DEVICE_FRAME_LIGHT_BORDER)
+          ),
           1
         ),
-        BorderFactory.createEmptyBorder(2, 2, 2, 2) // Small inner padding
+        BorderFactory.createEmptyBorder(
+          DeviceEmulationConstants.DEVICE_FRAME_INNER_PADDING,
+          DeviceEmulationConstants.DEVICE_FRAME_INNER_PADDING,
+          DeviceEmulationConstants.DEVICE_FRAME_INNER_PADDING,
+          DeviceEmulationConstants.DEVICE_FRAME_INNER_PADDING
+        )
       )
 
       // Ensure browser component respects the scaled device frame size

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
@@ -1,0 +1,371 @@
+package com.github.gbrowser.actions
+
+import com.github.gbrowser.ui.gcef.GCefBrowser
+import com.github.gbrowser.util.DeviceProfile
+import com.github.gbrowser.util.GBrowserDeviceEmulationUtil
+import com.github.gbrowser.util.GBrowserThemeUtil
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
+import com.intellij.util.ui.JBUI
+import java.awt.*
+import javax.swing.*
+import kotlin.math.ln
+
+object GBrowserMobileToggleActionUI {
+  private val LOG = thisLogger()
+
+  fun createDeviceToolbar(browser: GCefBrowser, state: DeviceEmulationState): JPanel {
+    val deviceComboBox = createDeviceComboBox(browser, state)
+    val widthSpinner = createWidthSpinner(state, browser)
+    val heightSpinner = createHeightSpinner(state, browser)
+    val zoomComboBox = createZoomComboBox(browser)
+    val rotateButton = createRotateButton(browser, state, widthSpinner, heightSpinner)
+
+    return JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 5, 2)).apply {
+      // Match Chrome DevTools toolbar styling
+      val isDarkTheme = GBrowserThemeUtil.isDarkTheme(browser.project)
+      background = if (isDarkTheme) {
+        JBColor(Color(0x2B2D30), Color(0x2B2D30)) // Chrome DevTools toolbar dark background
+      } else {
+        JBColor(Color(0xF3F3F3), Color(0xF3F3F3)) // Chrome DevTools toolbar light background  
+      }
+      border = JBUI.Borders.compound(
+        JBUI.Borders.customLine(
+          if (isDarkTheme) JBColor(Color(0x393B3F), Color(0x393B3F)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
+          0, 0, 1, 0
+        ),
+        JBUI.Borders.empty(5, 10)
+      )
+
+      // Device selector
+      add(deviceComboBox)
+
+      // Size controls
+      add(Box.createHorizontalStrut(10))
+      add(widthSpinner)
+      add(JBLabel("×").apply {
+        border = JBUI.Borders.empty(0, 3)
+      })
+      add(heightSpinner)
+
+      // Zoom controls
+      add(Box.createHorizontalStrut(10))
+      add(zoomComboBox)
+      add(JBLabel("%"))
+
+      // Action buttons
+      add(Box.createHorizontalStrut(10))
+      add(rotateButton)
+    }
+  }
+
+  private fun createDeviceComboBox(browser: GCefBrowser, state: DeviceEmulationState): ComboBox<String> {
+    return ComboBox<String>().apply {
+      // Add "Responsive" as default
+      addItem("Responsive")
+
+      // Add all device profiles
+      GBrowserDeviceEmulationUtil.DEVICE_PROFILES.keys.forEach { deviceName ->
+        addItem(deviceName)
+      }
+
+      // Add action listener
+      addActionListener { _ ->
+        when (val selected = selectedItem as? String) {
+          "Responsive" -> {
+            LOG.info("GBrowserMobileToggleAction: Selected Responsive mode")
+            applyResponsiveMode(browser, state)
+          }
+          null -> {
+            LOG.info("GBrowserMobileToggleAction: No device selected")
+          }
+          else -> {
+            LOG.info("GBrowserMobileToggleAction: Selected device: $selected")
+            GBrowserDeviceEmulationUtil.DEVICE_PROFILES[selected]?.let { profile ->
+              applyDeviceProfile(browser, profile, state)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun createWidthSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
+    return JSpinner(SpinnerNumberModel(state.currentWidth, 50, 9999, 1)).apply {
+      name = "widthSpinner"
+      preferredSize = Dimension(80, preferredSize.height)
+      addChangeListener {
+        val newWidth = value as Int
+        if (state.currentWidth != newWidth) {
+          LOG.debug("GBrowserMobileToggleAction: Width changed from ${state.currentWidth} to $newWidth")
+          state.currentWidth = newWidth
+          updateDeviceSize(browser, state)
+        }
+      }
+    }
+  }
+
+  private fun createHeightSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
+    return JSpinner(SpinnerNumberModel(state.currentHeight, 50, 9999, 1)).apply {
+      name = "heightSpinner"
+      preferredSize = Dimension(80, preferredSize.height)
+      addChangeListener {
+        val newHeight = value as Int
+        if (state.currentHeight != newHeight) {
+          LOG.debug("GBrowserMobileToggleAction: Height changed from ${state.currentHeight} to $newHeight")
+          state.currentHeight = newHeight
+          updateDeviceSize(browser, state)
+        }
+      }
+    }
+  }
+
+  private fun createZoomComboBox(browser: GCefBrowser): ComboBox<String> {
+    return ComboBox(arrayOf("50%", "75%", "100%", "125%", "150%")).apply {
+      selectedItem = "100%"
+      isEditable = true
+      preferredSize = Dimension(80, preferredSize.height)
+      addActionListener {
+        val zoomText = selectedItem as? String ?: return@addActionListener
+        val zoomValue = zoomText.removeSuffix("%").toDoubleOrNull() ?: return@addActionListener
+        val zoom = zoomValue / 100.0
+        val zoomLevel = ln(zoom) / ln(1.2)
+        LOG.debug("GBrowserMobileToggleAction: Zoom changed to $zoomText, zoom level: $zoomLevel")
+        browser.cefBrowser.zoomLevel = zoomLevel
+      }
+    }
+  }
+
+  private fun createRotateButton(
+    browser: GCefBrowser,
+    state: DeviceEmulationState,
+    widthSpinner: JSpinner,
+    heightSpinner: JSpinner
+  ): JButton {
+    return JButton(AllIcons.Actions.SyncPanels).apply {
+      toolTipText = "Rotate"
+      preferredSize = Dimension(30, 26)
+      addActionListener {
+        state.isRotated = !state.isRotated
+        // Swap width and height
+        val temp = state.currentWidth
+        state.currentWidth = state.currentHeight
+        state.currentHeight = temp
+
+        LOG.debug("GBrowserMobileToggleAction: Rotated device - new dimensions: ${state.currentWidth}x${state.currentHeight}")
+
+        // Update spinners
+        widthSpinner.value = state.currentWidth
+        heightSpinner.value = state.currentHeight
+
+        // Update device
+        updateDeviceSize(browser, state)
+      }
+    }
+  }
+
+  fun applyResponsiveMode(browser: GCefBrowser, state: DeviceEmulationState) {
+    state.currentDevice = "Responsive"
+
+    // Set default responsive size
+    if (state.currentWidth == 0 || state.currentHeight == 0) {
+      state.currentWidth = 400
+      state.currentHeight = 626
+    }
+
+    LOG.info("GBrowserMobileToggleAction: Applying responsive mode with dimensions ${state.currentWidth}x${state.currentHeight}")
+
+    // Update the device frame with responsive dimensions
+    updateDeviceFrame(browser, state)
+
+    // Update spinners
+    updateSpinnersFromState(state)
+
+    // Reset any device-specific emulation
+    GBrowserDeviceEmulationUtil.resetDeviceEmulation(browser.cefBrowser)
+
+    // Apply responsive mode with custom dimensions
+    val responsiveProfile = DeviceProfile(
+      name = "Responsive",
+      width = state.currentWidth,
+      height = state.currentHeight,
+      deviceScaleFactor = 1.0,
+      userAgent = browser.cefBrowser.url?.let {
+        // Use a mobile user agent for responsive mode
+        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      } ?: "",
+      isMobile = true,
+      hasTouch = true
+    )
+
+    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, responsiveProfile)
+
+    state.browserWrapper?.revalidate()
+    state.browserWrapper?.repaint()
+  }
+
+  fun applyDeviceProfile(browser: GCefBrowser, profile: DeviceProfile, state: DeviceEmulationState) {
+    state.currentDevice = profile.name
+    state.currentWidth = profile.width
+    state.currentHeight = profile.height
+    state.isRotated = false
+
+    LOG.info("GBrowserMobileToggleAction: Applying device profile '${profile.name}' with dimensions ${profile.width}x${profile.height}")
+
+    // Update browser wrapper to show device frame first
+    updateDeviceFrame(browser, state)
+
+    // Update spinners
+    updateSpinnersFromState(state)
+
+    // Apply JavaScript emulation after frame is set
+    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, profile)
+
+    // Reload the page to apply all changes
+    browser.cefBrowser.reload()
+
+    state.browserWrapper?.revalidate()
+    state.browserWrapper?.repaint()
+  }
+
+  fun updateDeviceFrame(browser: GCefBrowser, state: DeviceEmulationState) {
+    val wrapper = state.browserWrapper ?: return
+    wrapper.removeAll()
+
+    // Get available space in the wrapper (accounting for padding)
+    val wrapperWidth = wrapper.width
+    val wrapperHeight = wrapper.height
+
+    // If wrapper dimensions are not yet set, use the device dimensions as-is
+    if (wrapperWidth <= 40 || wrapperHeight <= 40) {
+      LOG.info("GBrowserMobileToggleAction: Wrapper dimensions not ready ($wrapperWidth x $wrapperHeight), using device dimensions as-is")
+      updateDeviceFrameWithDimensions(browser, state, state.currentWidth, state.currentHeight, 1.0)
+      return
+    }
+
+    val availableWidth = wrapperWidth - 40 // 20px padding on each side
+    val availableHeight = wrapperHeight - 40 // 20px padding on top/bottom
+
+    // Calculate scale if the device is too large
+    var deviceWidth = state.currentWidth
+    var deviceHeight = state.currentHeight
+    var scale = 1.0
+
+    if (deviceWidth > availableWidth || deviceHeight > availableHeight) {
+      val scaleX = availableWidth.toDouble() / deviceWidth
+      val scaleY = availableHeight.toDouble() / deviceHeight
+      scale = minOf(scaleX, scaleY, 1.0) // Never scale up, only down
+
+      // Apply scale with some margin
+      scale *= 0.9 // 90% to ensure some padding
+      deviceWidth = (state.currentWidth * scale).toInt()
+      deviceHeight = (state.currentHeight * scale).toInt()
+    }
+
+    LOG.info("GBrowserMobileToggleAction: Updating device frame - Original: ${state.currentWidth}x${state.currentHeight}, Scaled: ${deviceWidth}x${deviceHeight} (scale: $scale)")
+
+    updateDeviceFrameWithDimensions(browser, state, deviceWidth, deviceHeight, scale)
+  }
+
+  fun updateSpinnersFromState(state: DeviceEmulationState) {
+    state.deviceToolbar?.components?.forEach { component ->
+      if (component is JSpinner) {
+        when (component.name) {
+          "widthSpinner" -> {
+            LOG.debug("GBrowserMobileToggleAction: Setting width spinner to ${state.currentWidth}")
+            component.value = state.currentWidth
+          }
+          "heightSpinner" -> {
+            LOG.debug("GBrowserMobileToggleAction: Setting height spinner to ${state.currentHeight}")
+            component.value = state.currentHeight
+          }
+        }
+      }
+    }
+  }
+
+  fun updateDeviceSize(browser: GCefBrowser, state: DeviceEmulationState) {
+    LOG.debug("GBrowserMobileToggleAction: updateDeviceSize - ${state.currentWidth}x${state.currentHeight}")
+
+    // Create custom device profile with current dimensions
+    val customProfile = DeviceProfile(
+      name = "Custom",
+      width = state.currentWidth,
+      height = state.currentHeight,
+      deviceScaleFactor = 1.0,
+      userAgent = browser.cefBrowser.url?.let {
+        "Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      } ?: ""
+    )
+
+    // Apply the custom profile
+    GBrowserDeviceEmulationUtil.applyDeviceEmulation(browser.cefBrowser, customProfile)
+
+    // Update the frame
+    updateDeviceFrame(browser, state)
+  }
+
+  private fun updateDeviceFrameWithDimensions(browser: GCefBrowser, state: DeviceEmulationState, deviceWidth: Int, deviceHeight: Int, scale: Double) {
+    val wrapper = state.browserWrapper ?: return
+    // Get project from browser
+    val project = browser.project
+
+    // Create device frame panel
+    val deviceFrame = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+      preferredSize = Dimension(deviceWidth, deviceHeight)
+      minimumSize = preferredSize
+      maximumSize = preferredSize
+
+      // Match Chrome DevTools styling
+      val isDarkTheme = GBrowserThemeUtil.isDarkTheme(project)
+      background = if (isDarkTheme) {
+        JBColor(Color(0x292A2D), Color(0x292A2D)) // Slightly lighter than the wrapper for contrast
+      } else {
+        JBColor(Color(0xFFFFFF), Color(0xFFFFFF)) // White for light theme
+      }
+      border = BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(
+          if (isDarkTheme) JBColor(Color(0x3C3F41), Color(0x3C3F41)) else JBColor(Color(0xD0D0D0), Color(0xD0D0D0)),
+          1
+        ),
+        BorderFactory.createEmptyBorder(2, 2, 2, 2) // Small inner padding
+      )
+
+      // Ensure browser component respects the scaled device frame size
+      browser.component.preferredSize = Dimension(deviceWidth, deviceHeight)
+      browser.component.minimumSize = Dimension(deviceWidth, deviceHeight)
+      browser.component.maximumSize = Dimension(deviceWidth, deviceHeight)
+
+      // Add the browser component
+      add(browser.component, BorderLayout.CENTER)
+    }
+
+    val constraints = GridBagConstraints().apply {
+      gridx = 0
+      gridy = 0
+      anchor = GridBagConstraints.CENTER
+    }
+
+    wrapper.add(deviceFrame, constraints)
+    wrapper.revalidate()
+    wrapper.repaint()
+
+    // Force browser to recognize the new size
+    browser.component.revalidate()
+    // Use original dimensions for the browser viewport, not scaled dimensions
+    browser.cefBrowser.wasResized(state.currentWidth, state.currentHeight)
+
+    // Apply zoom if scaled
+    if (scale < 1.0) {
+      val zoomLevel = ln(scale) / ln(1.2)
+      browser.cefBrowser.zoomLevel = zoomLevel
+      LOG.info("GBrowserMobileToggleAction: Applied zoom level $zoomLevel for scale $scale")
+    }
+
+    LOG.info("GBrowserMobileToggleAction: Device frame updated and browser resized")
+  }
+}

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
@@ -191,8 +191,8 @@ object GBrowserMobileToggleActionUI {
 
     // Set default responsive size
     if (state.currentWidth == 0 || state.currentHeight == 0) {
-      state.currentWidth = DeviceEmulationConstants.RESPONSIVE_MODE_WIDTH
-      state.currentHeight = DeviceEmulationConstants.RESPONSIVE_MODE_HEIGHT
+      state.currentWidth = DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH
+      state.currentHeight = DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT
     }
 
     LOG.info("GBrowserMobileToggleAction: Applying responsive mode with dimensions ${state.currentWidth}x${state.currentHeight}")

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
@@ -96,7 +96,7 @@ object GBrowserMobileToggleActionUI {
 
   private fun createWidthSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
     return JSpinner(SpinnerNumberModel(state.currentWidth, 50, 9999, 1)).apply {
-      name = "widthSpinner"
+      name = "device-width-spinner"
       preferredSize = Dimension(80, preferredSize.height)
       addChangeListener {
         val newWidth = value as Int
@@ -111,7 +111,7 @@ object GBrowserMobileToggleActionUI {
 
   private fun createHeightSpinner(state: DeviceEmulationState, browser: GCefBrowser): JSpinner {
     return JSpinner(SpinnerNumberModel(state.currentHeight, 50, 9999, 1)).apply {
-      name = "heightSpinner"
+      name = "device-height-spinner"
       preferredSize = Dimension(80, preferredSize.height)
       addChangeListener {
         val newHeight = value as Int
@@ -275,11 +275,11 @@ object GBrowserMobileToggleActionUI {
     state.deviceToolbar?.components?.forEach { component ->
       if (component is JSpinner) {
         when (component.name) {
-          "widthSpinner" -> {
+          "device-width-spinner" -> {
             LOG.debug("GBrowserMobileToggleAction: Setting width spinner to ${state.currentWidth}")
             component.value = state.currentWidth
           }
-          "heightSpinner" -> {
+          "device-height-spinner" -> {
             LOG.debug("GBrowserMobileToggleAction: Setting height spinner to ${state.currentHeight}")
             component.value = state.currentHeight
           }

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUI.kt
@@ -191,8 +191,8 @@ object GBrowserMobileToggleActionUI {
 
     // Set default responsive size
     if (state.currentWidth == 0 || state.currentHeight == 0) {
-      state.currentWidth = 400
-      state.currentHeight = 626
+      state.currentWidth = DeviceEmulationConstants.RESPONSIVE_MODE_WIDTH
+      state.currentHeight = DeviceEmulationConstants.RESPONSIVE_MODE_HEIGHT
     }
 
     LOG.info("GBrowserMobileToggleAction: Applying responsive mode with dimensions ${state.currentWidth}x${state.currentHeight}")

--- a/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUtils.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUtils.kt
@@ -1,0 +1,60 @@
+package com.github.gbrowser.actions
+
+import com.github.gbrowser.ui.gcef.GCefBrowser
+import com.github.gbrowser.util.GBrowserToolWindowUtil
+import com.github.gbrowser.util.GBrowserUtil
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.wm.ToolWindowManager
+
+object GBrowserMobileToggleActionUtils {
+  private val LOG = thisLogger()
+
+  fun getCurrentBrowser(project: Project): GCefBrowser? {
+    LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - looking for browser in the project")
+
+    // First try to get from the regular browser window
+    val browserPanel = GBrowserToolWindowUtil.getSelectedBrowserPanel(project)
+    if (browserPanel != null) {
+      val browser = browserPanel.getBrowser()
+      LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - found browser in the main panel: ${browser.id}")
+      return browser
+    }
+
+    // If not found, try to get from DevTools window
+    val toolWindowManager = project.getService(ToolWindowManager::class.java)
+    val devToolsWindow = toolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID)
+    val selectedContent = devToolsWindow?.contentManager?.selectedContent
+    val devToolsPanel = selectedContent?.component as? com.github.gbrowser.ui.toolwindow.dev_tools.GBrowserToolWindowDevTools
+
+    val devBrowser = devToolsPanel?.browser
+    LOG.debug("GBrowserMobileToggleAction: getCurrentBrowser - devtools browser: ${devBrowser?.id}")
+    return devBrowser
+  }
+
+  fun getBrowserPanel(project: Project): SimpleToolWindowPanel? {
+    LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - looking for the browser panel")
+
+    // Get the browser tool window panel directly - it should be a SimpleToolWindowPanel
+    val browserPanel = GBrowserToolWindowUtil.getSelectedBrowserPanel(project)
+    if (browserPanel is SimpleToolWindowPanel) {
+      LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - found the main browser panel")
+      return browserPanel
+    }
+
+    // If not found, try to get from DevTools window
+    val toolWindowManager = project.getService(ToolWindowManager::class.java)
+    val devToolsWindow = toolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID)
+    val selectedContent = devToolsWindow?.contentManager?.selectedContent
+    val devToolsPanel = selectedContent?.component
+
+    if (devToolsPanel is SimpleToolWindowPanel) {
+      LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - found devtools panel")
+      return devToolsPanel
+    }
+
+    LOG.debug("GBrowserMobileToggleAction: getBrowserPanel - no panel found")
+    return null
+  }
+}

--- a/src/main/kotlin/com/github/gbrowser/reports/GBrowserPluginErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/github/gbrowser/reports/GBrowserPluginErrorReportSubmitter.kt
@@ -29,7 +29,7 @@ internal class GBrowserPluginErrorReportSubmitter : ErrorReportSubmitter() {
                       consumer: Consumer<in SubmittedReportInfo?>): Boolean {
     val event = events.first()
     val throwableText = event.throwableText
-    val throwableTextTitle = throwableText.take(100)
+    val throwableTextTitle = throwableText.take(throwableText.length.coerceAtMost(100))
     val reportStringBuilder = buildReportUrl(event, throwableTextTitle, additionalInfo)
 
     BrowserUtil.browse(reportStringBuilder.toString())

--- a/src/main/kotlin/com/github/gbrowser/reports/GBrowserPluginErrorReportSubmitter.kt
+++ b/src/main/kotlin/com/github/gbrowser/reports/GBrowserPluginErrorReportSubmitter.kt
@@ -29,7 +29,7 @@ internal class GBrowserPluginErrorReportSubmitter : ErrorReportSubmitter() {
                       consumer: Consumer<in SubmittedReportInfo?>): Boolean {
     val event = events.first()
     val throwableText = event.throwableText
-    val throwableTextTitle = throwableText.take(throwableText.length.coerceAtMost(100))
+    val throwableTextTitle = throwableText.take(100)
     val reportStringBuilder = buildReportUrl(event, throwableTextTitle, additionalInfo)
 
     BrowserUtil.browse(reportStringBuilder.toString())

--- a/src/main/kotlin/com/github/gbrowser/services/GBrowserService.kt
+++ b/src/main/kotlin/com/github/gbrowser/services/GBrowserService.kt
@@ -1,5 +1,6 @@
 package com.github.gbrowser.services
 
+import com.github.gbrowser.actions.DeviceEmulationConstants
 import com.github.gbrowser.settings.bookmarks.GBrowserBookmark
 import com.github.gbrowser.settings.dao.GBrowserHistory
 import com.github.gbrowser.settings.request_header.GBrowserRequestHeader
@@ -43,7 +44,7 @@ class GBrowserService : SerializablePersistentStateComponent<GBrowserService.Set
                            var historyItemsToKeep: Int = 20,
                            var requestHeaders: MutableSet<GBrowserRequestHeader> = mutableSetOf(
                              GBrowserRequestHeader(
-                               "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 /CefSharp Browser 90.0",
+                               DeviceEmulationConstants.USER_AGENT_DEFAULT_BROWSER,
                                "User-Agent",
                                true
                              )

--- a/src/main/kotlin/com/github/gbrowser/ui/gcef/GCefBrowser.kt
+++ b/src/main/kotlin/com/github/gbrowser/ui/gcef/GCefBrowser.kt
@@ -1,5 +1,6 @@
 package com.github.gbrowser.ui.gcef
 
+import com.github.gbrowser.actions.DeviceEmulationConstants
 import com.github.gbrowser.actions.GBrowserMobileToggleAction
 import com.github.gbrowser.i18n.GBrowserBundle
 import com.github.gbrowser.services.GBrowserService
@@ -223,7 +224,7 @@ class GCefBrowser(val project: Project, url: String?, client: JBCefClient? = nul
     }
 
     // Reapply theme after resize to ensure it's properly rendered
-    javax.swing.Timer(100) {
+    javax.swing.Timer(DeviceEmulationConstants.THEME_UPDATE_DELAY_MS) {
       GBrowserThemeUtil.applyTheme(cefBrowser, project)
     }.apply {
       isRepeats = false
@@ -266,7 +267,7 @@ class GCefBrowser(val project: Project, url: String?, client: JBCefClient? = nul
 
   fun refreshTheme() {
     // Add a small delay to ensure the page is ready
-    javax.swing.Timer(100) {
+    javax.swing.Timer(DeviceEmulationConstants.THEME_UPDATE_DELAY_MS) {
       GBrowserThemeUtil.applyTheme(cefBrowser, project)
     }.apply {
       isRepeats = false

--- a/src/main/kotlin/com/github/gbrowser/util/GBrowserDeviceEmulationUtil.kt
+++ b/src/main/kotlin/com/github/gbrowser/util/GBrowserDeviceEmulationUtil.kt
@@ -1,5 +1,6 @@
 package com.github.gbrowser.util
 
+import com.github.gbrowser.actions.DeviceEmulationConstants
 import com.intellij.openapi.diagnostic.thisLogger
 import org.cef.browser.CefBrowser
 
@@ -41,119 +42,119 @@ object GBrowserDeviceEmulationUtil {
       width = 375,
       height = 667,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPHONE_SE
     ),
     "iPhone XR" to DeviceProfile(
       name = "iPhone XR",
       width = 414,
       height = 896,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPHONE_XR
     ),
     "iPhone 12 Pro" to DeviceProfile(
       name = "iPhone 12 Pro",
       width = 390,
       height = 844,
       deviceScaleFactor = 3.0,
-      userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPHONE_12_PRO
     ),
     "iPhone 14 Pro Max" to DeviceProfile(
       name = "iPhone 14 Pro Max",
       width = 430,
       height = 932,
       deviceScaleFactor = 3.0,
-      userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPHONE_XR
     ),
     "Pixel 7" to DeviceProfile(
       name = "Pixel 7",
       width = 412,
       height = 915,
       deviceScaleFactor = 2.625,
-      userAgent = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_PIXEL_7
     ),
     "Samsung Galaxy S8+" to DeviceProfile(
       name = "Samsung Galaxy S8+",
       width = 360,
       height = 740,
       deviceScaleFactor = 4.0,
-      userAgent = "Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_SAMSUNG_S8_PLUS
     ),
     "Samsung Galaxy S20 Ultra" to DeviceProfile(
       name = "Samsung Galaxy S20 Ultra",
       width = 412,
       height = 915,
       deviceScaleFactor = 3.5,
-      userAgent = "Mozilla/5.0 (Linux; Android 10; SM-G988B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_SAMSUNG_S20_ULTRA
     ),
     "iPad Mini" to DeviceProfile(
       name = "iPad Mini",
       width = 768,
       height = 1024,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPAD_MINI
     ),
     "iPad Air" to DeviceProfile(
       name = "iPad Air",
       width = 820,
       height = 1180,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPAD_MINI
     ),
     "iPad Pro" to DeviceProfile(
       name = "iPad Pro",
       width = 1024,
       height = 1366,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+      userAgent = DeviceEmulationConstants.USER_AGENT_IPAD_MINI
     ),
     "Surface Pro 7" to DeviceProfile(
       name = "Surface Pro 7",
       width = 912,
       height = 1368,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.0.0"
+      userAgent = DeviceEmulationConstants.USER_AGENT_SURFACE_PRO_7
     ),
     "Surface Duo" to DeviceProfile(
       name = "Surface Duo",
       width = 540,
       height = 720,
       deviceScaleFactor = 2.5,
-      userAgent = "Mozilla/5.0 (Linux; Android 11; Surface Duo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_SURFACE_DUO
     ),
     "Galaxy Z Fold 5" to DeviceProfile(
       name = "Galaxy Z Fold 5",
       width = 344,
       height = 882,
       deviceScaleFactor = 3.0,
-      userAgent = "Mozilla/5.0 (Linux; Android 13; SM-F946B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_GALAXY_Z_FOLD_5
     ),
     "Asus Zenbook Fold" to DeviceProfile(
       name = "Asus Zenbook Fold",
       width = 853,
       height = 1280,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_ASUS_ZENBOOK_FOLD
     ),
     "Samsung Galaxy A51/71" to DeviceProfile(
       name = "Samsung Galaxy A51/71",
       width = 412,
       height = 914,
       deviceScaleFactor = 2.625,
-      userAgent = "Mozilla/5.0 (Linux; Android 11; SM-A515F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+      userAgent = DeviceEmulationConstants.USER_AGENT_SAMSUNG_A51_71
     ),
     "Nest Hub" to DeviceProfile(
       name = "Nest Hub",
       width = 1024,
       height = 600,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
+      userAgent = DeviceEmulationConstants.USER_AGENT_NEST_HUB
     ),
     "Nest Hub Max" to DeviceProfile(
       name = "Nest Hub Max",
       width = 1280,
       height = 800,
       deviceScaleFactor = 2.0,
-      userAgent = "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 CrKey/1.56.500000"
+      userAgent = DeviceEmulationConstants.USER_AGENT_NEST_HUB_MAX
     )
   )
 

--- a/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
@@ -16,8 +16,8 @@ class DeviceEmulationStateTest {
     assertNull(state.deviceToolbar)
     assertNull(state.browserWrapper)
     assertFalse(state.isRotated)
-    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
-    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
+    assertEquals(DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
+    assertEquals(DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
   }
 
   @Test
@@ -60,8 +60,8 @@ class DeviceEmulationStateTest {
 
   @Test
   fun `test default responsive dimensions`() {
-    assertEquals(400, DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH)
-    assertEquals(626, DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT)
+    assertEquals(400, DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH)
+    assertEquals(626, DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT)
   }
 
   @Test
@@ -105,12 +105,12 @@ class DeviceEmulationStateTest {
       currentDevice = "Custom"
     )
 
-    state.currentWidth = DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH
-    state.currentHeight = DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT
+    state.currentWidth = DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH
+    state.currentHeight = DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT
     state.currentDevice = null
 
-    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
-    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
+    assertEquals(DeviceEmulationConstants.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
+    assertEquals(DeviceEmulationConstants.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
     assertNull(state.currentDevice)
   }
 }

--- a/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
@@ -63,4 +63,54 @@ class DeviceEmulationStateTest {
     assertEquals(400, DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH)
     assertEquals(626, DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT)
   }
+
+  @Test
+  fun `test state handles extreme dimensions`() {
+    val state = DeviceEmulationState(
+      currentWidth = 1,
+      currentHeight = 9999
+    )
+
+    assertEquals(1, state.currentWidth)
+    assertEquals(9999, state.currentHeight)
+  }
+
+  @Suppress("KotlinConstantConditions")
+  @Test
+  fun `test state cleans up correctly`() {
+    val toolbar = JPanel()
+    val wrapper = JBPanel<JBPanel<*>>()
+
+    val state = DeviceEmulationState(
+      isActive = true,
+      deviceToolbar = toolbar,
+      browserWrapper = wrapper
+    )
+
+    // Simulate cleanup
+    state.deviceToolbar = null
+    state.browserWrapper = null
+    state.isActive = false
+
+    assertNull(state.deviceToolbar)
+    assertNull(state.browserWrapper)
+    assertFalse(state.isActive)
+  }
+
+  @Test
+  fun `test state preserves default device values when reset`() {
+    val state = DeviceEmulationState(
+      currentWidth = 800,
+      currentHeight = 600,
+      currentDevice = "Custom"
+    )
+
+    state.currentWidth = DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH
+    state.currentHeight = DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT
+    state.currentDevice = null
+
+    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
+    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
+    assertNull(state.currentDevice)
+  }
 }

--- a/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/DeviceEmulationStateTest.kt
@@ -1,0 +1,66 @@
+package com.github.gbrowser.actions
+
+import com.intellij.ui.components.JBPanel
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import javax.swing.JPanel
+
+class DeviceEmulationStateTest {
+
+  @Test
+  fun `test default state values`() {
+    val state = DeviceEmulationState()
+
+    assertFalse(state.isActive)
+    assertNull(state.currentDevice)
+    assertNull(state.deviceToolbar)
+    assertNull(state.browserWrapper)
+    assertFalse(state.isRotated)
+    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH, state.currentWidth)
+    assertEquals(DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT, state.currentHeight)
+  }
+
+  @Test
+  fun `test state with custom values`() {
+    val toolbar = JPanel()
+    val wrapper = JBPanel<JBPanel<*>>()
+
+    val state = DeviceEmulationState(
+      isActive = true,
+      currentDevice = "iPhone 12",
+      deviceToolbar = toolbar,
+      browserWrapper = wrapper,
+      isRotated = true,
+      currentWidth = 800,
+      currentHeight = 600
+    )
+
+    assertTrue(state.isActive)
+    assertEquals("iPhone 12", state.currentDevice)
+    assertEquals(toolbar, state.deviceToolbar)
+    assertEquals(wrapper, state.browserWrapper)
+    assertTrue(state.isRotated)
+    assertEquals(800, state.currentWidth)
+    assertEquals(600, state.currentHeight)
+  }
+
+  @Test
+  fun `test state mutation`() {
+    val state = DeviceEmulationState()
+
+    state.isActive = true
+    state.currentDevice = "iPad Pro"
+    state.currentWidth = 1024
+    state.currentHeight = 768
+
+    assertEquals("iPad Pro", state.currentDevice)
+    assertEquals(1024, state.currentWidth)
+    assertEquals(768, state.currentHeight)
+  }
+
+  @Test
+  fun `test default responsive dimensions`() {
+    assertEquals(400, DeviceEmulationState.DEFAULT_RESPONSIVE_WIDTH)
+    assertEquals(626, DeviceEmulationState.DEFAULT_RESPONSIVE_HEIGHT)
+  }
+}

--- a/src/test/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUtilsTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/GBrowserMobileToggleActionUtilsTest.kt
@@ -1,0 +1,97 @@
+package com.github.gbrowser.actions
+
+import com.github.gbrowser.ui.gcef.GCefBrowser
+import com.github.gbrowser.ui.toolwindow.gbrowser.GBrowserToolWindowBrowser
+import com.github.gbrowser.util.GBrowserToolWindowUtil
+import com.github.gbrowser.util.GBrowserUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GBrowserMobileToggleActionUtilsTest {
+
+  private lateinit var mockProject: Project
+  private lateinit var mockToolWindowManager: ToolWindowManager
+  private lateinit var mockToolWindow: ToolWindow
+  private lateinit var mockBrowserPanel: GBrowserToolWindowBrowser
+  private lateinit var mockBrowser: GCefBrowser
+
+  @BeforeEach
+  fun setUp() {
+    mockProject = mockk(relaxed = true)
+    mockToolWindowManager = mockk(relaxed = true)
+    mockToolWindow = mockk(relaxed = true)
+    mockBrowserPanel = mockk(relaxed = true)
+    mockBrowser = mockk(relaxed = true)
+
+    every { mockProject.getService(ToolWindowManager::class.java) } returns mockToolWindowManager
+    every { mockBrowserPanel.getBrowser() } returns mockBrowser
+    every { mockBrowser.id } returns "test-browser-1"
+
+    mockkStatic(GBrowserToolWindowUtil::class)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `test getCurrentBrowser returns browser from main panel`() {
+    // Given
+    every { GBrowserToolWindowUtil.getSelectedBrowserPanel(mockProject) } returns mockBrowserPanel
+
+    // When
+    val result = GBrowserMobileToggleActionUtils.getCurrentBrowser(mockProject)
+
+    // Then
+    assertEquals(mockBrowser, result)
+    verify { GBrowserToolWindowUtil.getSelectedBrowserPanel(mockProject) }
+  }
+
+  @Test
+  fun `test getCurrentBrowser returns null when no browser found`() {
+    // Given
+    every { GBrowserToolWindowUtil.getSelectedBrowserPanel(mockProject) } returns null
+    every { mockToolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID) } returns null
+
+    // When
+    val result = GBrowserMobileToggleActionUtils.getCurrentBrowser(mockProject)
+
+    // Then
+    assertNull(result)
+  }
+
+  @Test
+  fun `test getBrowserPanel returns SimpleToolWindowPanel from main browser`() {
+    // Given
+    // GBrowserToolWindowBrowser extends SimpleToolWindowPanel
+    every { GBrowserToolWindowUtil.getSelectedBrowserPanel(mockProject) } returns mockBrowserPanel
+
+    // When
+    val result = GBrowserMobileToggleActionUtils.getBrowserPanel(mockProject)
+
+    // Then,
+    // Since GBrowserToolWindowBrowser is a SimpleToolWindowPanel, it should be returned
+    assertEquals(mockBrowserPanel, result)
+  }
+
+  @Test
+  fun `test getBrowserPanel returns null when no panel found`() {
+    // Given
+    every { GBrowserToolWindowUtil.getSelectedBrowserPanel(mockProject) } returns null
+    every { mockToolWindowManager.getToolWindow(GBrowserUtil.DEVTOOLS_TOOL_WINDOW_ID) } returns null
+
+    // When
+    val result = GBrowserMobileToggleActionUtils.getBrowserPanel(mockProject)
+
+    // Then
+    assertNull(result)
+  }
+}


### PR DESCRIPTION
### Summary

This pull request introduces mobile emulation support, including the following features:
- **GBrowserMobileToggleAction**: Implements mobile emulation toggle.
- **Device Toolbar**: Allows users to select devices and manage rotation controls.
- **Responsive Mode**: Adds functionality for adaptable screen behavior.
- **Improved Scaling Logic**: Enhances proper display scaling across varied devices.

Additionally, tests are extended to cover state management, new utilities, and edge cases.

### Checklist

- [ ] Code reviewed
- [ ] Tests added/updated
- [ ] Documentation updated, if necessary