### PR TITLE
Update CHANGELOG for 2025.2.4 release

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,12 @@
       "Bash(cat:*)",
       "Bash(mkdir:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "WebFetch(domain:docs.codecov.com)",
+      "Bash(curl:*)",
+      "Bash(chmod:*)",
+      "Bash(./codecov:*)",
+      "Bash(gh repo view:*)"
     ],
     "deny": []
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- 🪲 Fixed an issue running action on EDT.
+- 🪲 Fixed threading issue by moving GBrowserOpenCurrentFileAction to background thread (BGT)
 
 ## [2025.2.3] - 2025-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- 🚀 Support for the latest 2025.2
+- 🚀 Emulation device support. You can now emulate different devices in the browser
+- 🚀 Support theme switching. You can now switch between different themes in the browser
+
+### Fixed
+
+- 🪲 Fixed an issue with the tool window not opening correctly [Issue #224](https://github.com/edgafner/dorkag/issues/224)
+- 🪲 Fixed various concurrency issues in the browser
+
 ## [2025.2.3] - 2025-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- 🚀 Support for the latest 2025.2
-- 🚀 Emulation device support. You can now emulate different devices in the browser
-- 🚀 Support theme switching. You can now switch between different themes in the browser
+- 🚀 Changelog and Gradle platform updated version
 
 ### Fixed
 
-- 🪲 Fixed an issue with the tool window not opening correctly [Issue #224](https://github.com/edgafner/dorkag/issues/224)
-- 🪲 Fixed various concurrency issues in the browser
+- 🪲 Fixed an issue running action on EDT.
 
 ## [2025.2.3] - 2025-07-26
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup=com.github.jonatha1983.gib
 pluginName=GBrowser
 pluginRepositoryUrl=https://github.com/edgafner/GBrowser
-pluginVersion=2025.2.3
+pluginVersion=2025.2.4
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=252
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-changelog = "2.2.1"
-intelliJPlatform = "2.6.0"
+changelog = "2.3.0"
+intelliJPlatform = "2.7.0"
 kotlin = "2.2.0"
 kover = "0.9.1"
 qodana = "2025.1.1"

--- a/src/main/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileAction.kt
+++ b/src/main/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileAction.kt
@@ -22,7 +22,7 @@ class GBrowserOpenCurrentFileAction : AnAction(), DumbAware {
 
   private val supportedExtensions = setOf("html", "htm", "xhtml", "xml", "svg", "md", "markdown")
 
-  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
   override fun update(e: AnActionEvent) {
     val file = getCurrentFile(e)

--- a/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
@@ -39,7 +39,7 @@ class GBrowserOpenCurrentFileActionTest {
 
   @Test
   fun `test action update thread is EDT`() {
-    assertEquals(ActionUpdateThread.EDT, action.actionUpdateThread)
+    assertEquals(ActionUpdateThread.BGT, action.actionUpdateThread)
   }
 
   @Test

--- a/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
@@ -38,7 +38,7 @@ class GBrowserOpenCurrentFileActionTest {
   }
 
   @Test
-  fun `test action update thread is EDT`() {
+  fun `test action update thread is BGT`() {
     assertEquals(ActionUpdateThread.BGT, action.actionUpdateThread)
   }
 

--- a/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
+++ b/src/test/kotlin/com/github/gbrowser/actions/editor/GBrowserOpenCurrentFileActionTest.kt
@@ -42,6 +42,7 @@ class GBrowserOpenCurrentFileActionTest {
     assertEquals(ActionUpdateThread.BGT, action.actionUpdateThread)
   }
 
+  @Suppress("UnusedVariable")
   @Test
   fun `test supported extensions are defined`() {
     // This tests that the action has the expected supported extensions

--- a/src/uiTest/kotlin/com/github/gbrowser/ui/Setup.kt
+++ b/src/uiTest/kotlin/com/github/gbrowser/ui/Setup.kt
@@ -33,7 +33,7 @@ class Setup {
     fun setupTestContext(hyphenateWithClass: String): IDETestContext {
 
       val testCase = TestCase(
-        IdeProductProvider.IC.copy(buildNumber = "252.23892.248", buildType = BuildType.EAP.type), NoProject
+        IdeProductProvider.IC.copy(buildNumber = "252.23892.360", buildType = BuildType.RC.type), NoProject
       )
       return Starter.newContext(testName = hyphenateWithClass, testCase = testCase).apply {
         val pluginPath = System.getProperty("path.to.build.plugin")


### PR DESCRIPTION
This pull request includes updates to the changelog, dependency versions, and a bug fix for a threading issue. The most important changes are grouped below:

### Changelog and version updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12): Updated with notes on the version change and a fix for running actions on the EDT thread.
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L7-R7): Incremented the `pluginVersion` from `2025.2.3` to `2025.2.4`.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R3): Updated `changelog` version to `2.3.0` and `intelliJPlatform` version to `2.7.0`.

### Bug fix:

* [`GBrowserOpenCurrentFileAction.kt`](diffhunk://#diff-44069042195c2571d50a04691bb486877c1cf9346bb961551ce979b7403a17bcL25-R25): Changed the `getActionUpdateThread` method to use `ActionUpdateThread.BGT` instead of `ActionUpdateThread.EDT` to resolve a threading issue.