### PR TITLE
Bump plugin version and improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,15 +76,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
-
-
-      # Upload an artifact as a release asset
-      - name: Upload Mapping
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/*.txt
-
-
+      
+      
       # Create a pull request
       - name: Create Pull Request
         if: ${{ steps.changelog_changes.outputs.has_changes == 'true' }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup=com.github.jonatha1983.gib
 pluginName=GBrowser
 pluginRepositoryUrl=https://github.com/edgafner/GBrowser
-pluginVersion=2025.2.5
+pluginVersion=2025.2.6
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=252
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension


### PR DESCRIPTION
---
- Bumps the plugin version to `2025.2.6` in `gradle.properties`.
- Cleans up and optimizes the release workflow. 

No issues linked to this pull request.