### PR TITLE
Fix invalid HTML tag in UI DSL text() function

### DIFF
--- a/src/main/kotlin/com/github/gbrowser/settings/project/GBrowserProjectSettingsComponent.kt
+++ b/src/main/kotlin/com/github/gbrowser/settings/project/GBrowserProjectSettingsComponent.kt
@@ -221,8 +221,8 @@ class GBrowserProjectSettingsComponent(val project: Project) : SimpleToolWindowP
     collapsibleGroup("Browser Compatibility Mode", true) {
       row {
         text(
-          "<html><b>About:</b> Makes the IDE's embedded browser compatible with sites that incorrectly block development tools.<br>" +
-            "This helps developers access documentation, cloud consoles, and test their own applications.</html>"
+          "<b>About:</b> Makes the IDE's embedded browser compatible with sites that incorrectly block development tools.<br>" +
+            "This helps developers access documentation, cloud consoles, and test their own applications."
         )
       }
       lateinit var enableCheckbox: Cell<JCheckBox>


### PR DESCRIPTION
Fixes #502

Removed <html> and </html> tags from text() function call in antiDetectionOptions(). According to IntelliJ Platform UI DSL documentation, the text() function automatically wraps content in <html> tags, and manually including them causes a validation error.

The framework explicitly denies <html> and <body> tags as they are added automatically by HtmlBuilder and HtmlChunk utilities. Other HTML tags like <b> and <br> remain supported.

Reference: platform/platform-impl/src/com/intellij/ui/dsl/builder/Row.kt
          platform/platform-impl/src/com/intellij/ui/dsl/builder/components/DslLabel.kt
This pull request makes a minor update to the browser compatibility mode description in the project settings UI. The change removes the unnecessary `<html>` tag from the description text to improve consistency and readability.

* Updated the browser compatibility mode description in the `GBrowserProjectSettingsComponent` to remove the `<html>` tag from the `text` call.