### PR TITLE
Create New Project Setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
   alias(libs.plugins.intelliJPlatform)
   alias(libs.plugins.changelog)
   alias(libs.plugins.qodana)
-  kotlin("plugin.serialization") version "2.2.20"
+  kotlin("plugin.serialization") version "2.2.21"
   alias(libs.plugins.kover)
   idea
 }
@@ -83,10 +83,10 @@ dependencies { // IntelliJ Platform dependencies
   }
 
   // Implementation dependencies
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.20.0") { isTransitive = false }
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.0") { isTransitive = false }
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.20.1") { isTransitive = false }
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1") { isTransitive = false }
   implementation("com.fasterxml.jackson.core:jackson-databind:2.20.1") { isTransitive = false }
-  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.0") { isTransitive = false }
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1") { isTransitive = false }
   compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
 


### PR DESCRIPTION
This PR consolidates multiple dependency updates:
- Bump kotlin plugin.serialization from 2.2.20 to 2.2.21
- Bump jackson-module-kotlin from 2.20.0 to 2.20.1
- Bump jackson-datatype-jsr310 from 2.20.0 to 2.20.1
- Bump jackson-dataformat-yaml from 2.20.0 to 2.20.1

These are patch version updates that include bug fixes and security improvements.