### PR TITLE
release/2026.2-fixes: open patch branch for IDE 2026.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,16 @@
 pluginGroup=com.github.jonatha1983.gib
 pluginName=GBrowser
 pluginRepositoryUrl=https://github.com/edgafner/GBrowser
-pluginVersion=2026.2.3
+pluginVersion=2026.2.4
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=262.8665
 pluginUntilBuild=262.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType=IU
 # 2026.2 GA (build IU-262.8665.258). Keep aligned with pluginSinceBuild above and Setup.kt's
-# useRelease() pin — bump all together when moving to a 2026.2.x patch release.
+# useRelease("2026.2") pin — bump all together when moving to a 2026.2.x patch release.
+# This is the long-lived release/2026.2-fixes maintenance branch: main targets the 2026.3 EAP.
+# Never raise these to 263 here; backports land via /release-branch-update.
 # Note: the JCEF module deps in plugin.xml require >= 262.8117 (intellij.libraries.jcef visibility).
 platformVersion=2026.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION
Opens the long-lived patch branch for IntelliJ IDEA 2026.2 users while `main`
moves to `263-EAP-SNAPSHOT`.

Freezes the 2026.2 GA configuration:
- `platformVersion=2026.2` (IU-262.8665.258)
- `pluginSinceBuild=262.8665`, `pluginUntilBuild=262.*`
- uiTest `Setup.kt` → `useRelease("2026.2")`
- `pluginVersion` → `2026.2.4` to start the next patch series

⚠️ **This PR is not for merge.** Release branches never merge back into `main`.
It is kept as a draft so the pinned configuration is reviewable and so future
backports have a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)